### PR TITLE
Add support for arrays within steps

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -14,6 +14,7 @@ import (
 
 func init() {
 	gob.Register(make(map[interface{}]interface{}))
+	gob.Register(make([]interface{}, 0))
 }
 
 type Pipeline struct {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestDeepCopyStep(t *testing.T) {
+	// pipeline := &Pipeline{}
+	step := Step{}
+	stepBytes := []byte(`
+command: my command
+agents:
+  mytag: myval
+plugins:
+  - docker#v3.7.0:
+      image: "node:12.19-alpine-3.12"
+`)
+	err := yaml.Unmarshal(stepBytes, &step)
+	if err != nil {
+		t.Error("unmarshal failed:", err)
+	}
+	if step["command"] != "my command" {
+		t.Error("failed to parse step", step["command"])
+	}
+	deepCopyStep(step)
+}


### PR DESCRIPTION
Fixes `panic: gob: type not registered for interface: []interface {}` when you try to create a step that has an array in it e.g. when you try to use [BuildKite plugins](https://buildkite.com/docs/plugins)