### PR TITLE
fix: Only add concurrency to command steps

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -226,7 +226,7 @@ func lowerStep(step Step, context *Context, stepContext *StepContext) (Step, err
 	}
 	step["name"] = strings.TrimSpace(fmt.Sprintf(":%s: %s", stepContext.EmojiName, name))
 
-	if stepContext.PreventConcurrency &&
+	if step["command"] != nil && stepContext.PreventConcurrency &&
 		step["concurrency"] == nil && step["concurrency_group"] == nil {
 		step["concurrency_group"] = fmt.Sprintf("%s/%s", stepContext.EnvironmentName, context.BuildkitePipelineSlug)
 		step["concurrency"] = 1

--- a/testdata/basic.in.yaml
+++ b/testdata/basic.in.yaml
@@ -8,6 +8,7 @@ deploy:
 - command: deploy
   env:
     ENVIRONMENT: ${environment}
+- wait: # concurrency should NOT be added to wait step
 - name: should not overwrite custom concurrency_group
   command: b
   concurrency_group: custom-group

--- a/testdata/basic_master.out.yaml
+++ b/testdata/basic_master.out.yaml
@@ -38,6 +38,8 @@ steps:
     JOBSWORTH_ENVIRONMENT: dev
     JOBSWORTH_SOURCE_GIT_COMMIT_ID: ""
   name: ':truck:'
+- name: ':truck:'
+  wait: null
 - agents:
     environment: dev
     queue: deploy
@@ -80,6 +82,8 @@ steps:
     JOBSWORTH_ENVIRONMENT: prod
     JOBSWORTH_SOURCE_GIT_COMMIT_ID: ""
   name: ':truck:'
+- name: ':truck:'
+  wait: null
 - agents:
     environment: prod
     queue: deploy


### PR DESCRIPTION
This is a follow-up to the previous PR https://github.com/saymedia/jobsworth/pull/6 which added `concurrency:1, concurrency_group: …` to all the `deploy` and `validation_test` steps.

Fix this error upon inserting new steps when the original pipeline had a `wait` step within `deploy` or `validation_test`: “error inserting new pipeline steps: POST `https://agent.buildkite.com/v3/jobs/<jobs>/pipelines`: 422 `concurrency` is not a valid property on the `wait` step. Please check the documentation to get a full list of supported properties.”

This change sets `concurrency:1, concurrency_group: …` only to steps with [Command steps](https://buildkite.com/docs/pipelines/command-step). Other [step types](https://buildkite.com/docs/pipelines/step-reference) (`wait`, `block`, `input`, `trigger`, `group`) do not get `concurrency` added.

We probably should descend into a [Group step](https://buildkite.com/docs/pipelines/group-step)’s steps, but we currently don’t support them at all.