### PR TITLE
Fix: reduce “Waiting on concurrency group”

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -132,7 +132,6 @@ func (p *Pipeline) Lower(context *Context) ([]interface{}, error) {
 							EnvironmentName:    envName,
 							QueueName:          "validation_test",
 							EmojiName:          "curly_loop",
-							PreventConcurrency: true,
 						}
 						loweredSteps, err := lowerSteps(
 							p.ValidationTest, context, stepContext,
@@ -157,7 +156,6 @@ func (p *Pipeline) Lower(context *Context) ([]interface{}, error) {
 					EnvironmentName:    envName,
 					QueueName:          "validation_test",
 					EmojiName:          "curly_loop",
-					PreventConcurrency: true,
 				}
 
 				// Manual deploys run sequentially, so that they can

--- a/pipeline.go
+++ b/pipeline.go
@@ -230,6 +230,9 @@ func lowerStep(step Step, context *Context, stepContext *StepContext) (Step, err
 		step["concurrency"] == nil && step["concurrency_group"] == nil {
 		step["concurrency_group"] = fmt.Sprintf("%s/%s", stepContext.EnvironmentName, context.BuildkitePipelineSlug)
 		step["concurrency"] = 1
+		if step["concurrency_method"] == nil {
+			step["concurrency_method"] = "eager"
+		}
 	}
 
 	return step, nil

--- a/pipeline.go
+++ b/pipeline.go
@@ -132,6 +132,7 @@ func (p *Pipeline) Lower(context *Context) ([]interface{}, error) {
 							EnvironmentName:    envName,
 							QueueName:          "validation_test",
 							EmojiName:          "curly_loop",
+							PreventConcurrency: true,
 						}
 						loweredSteps, err := lowerSteps(
 							p.ValidationTest, context, stepContext,
@@ -156,6 +157,7 @@ func (p *Pipeline) Lower(context *Context) ([]interface{}, error) {
 					EnvironmentName:    envName,
 					QueueName:          "validation_test",
 					EmojiName:          "curly_loop",
+					PreventConcurrency: true,
 				}
 
 				// Manual deploys run sequentially, so that they can

--- a/testdata/basic_master.out.yaml
+++ b/testdata/basic_master.out.yaml
@@ -59,6 +59,9 @@ steps:
     environment: dev
     queue: validation_test
   command: integrationtest
+  concurrency: 1
+  concurrency_group: dev/myrepo
+  concurrency_method: eager
   env:
     JOBSWORTH_CAUTIOUS: "0"
     JOBSWORTH_CODE_VERSION: ""
@@ -102,6 +105,9 @@ steps:
     environment: prod
     queue: validation_test
   command: integrationtest
+  concurrency: 1
+  concurrency_group: prod/myrepo
+  concurrency_method: eager
   env:
     JOBSWORTH_CAUTIOUS: "0"
     JOBSWORTH_CODE_VERSION: ""

--- a/testdata/basic_master.out.yaml
+++ b/testdata/basic_master.out.yaml
@@ -30,6 +30,7 @@ steps:
   command: deploy
   concurrency: 1
   concurrency_group: dev/myrepo
+  concurrency_method: eager
   env:
     ENVIRONMENT: dev
     JOBSWORTH_CAUTIOUS: "0"
@@ -60,6 +61,7 @@ steps:
   command: integrationtest
   concurrency: 1
   concurrency_group: dev/myrepo
+  concurrency_method: eager
   env:
     JOBSWORTH_CAUTIOUS: "0"
     JOBSWORTH_CODE_VERSION: ""
@@ -74,6 +76,7 @@ steps:
   command: deploy
   concurrency: 1
   concurrency_group: prod/myrepo
+  concurrency_method: eager
   env:
     ENVIRONMENT: prod
     JOBSWORTH_CAUTIOUS: "1"
@@ -104,6 +107,7 @@ steps:
   command: integrationtest
   concurrency: 1
   concurrency_group: prod/myrepo
+  concurrency_method: eager
   env:
     JOBSWORTH_CAUTIOUS: "0"
     JOBSWORTH_CODE_VERSION: ""

--- a/testdata/basic_master.out.yaml
+++ b/testdata/basic_master.out.yaml
@@ -59,9 +59,6 @@ steps:
     environment: dev
     queue: validation_test
   command: integrationtest
-  concurrency: 1
-  concurrency_group: dev/myrepo
-  concurrency_method: eager
   env:
     JOBSWORTH_CAUTIOUS: "0"
     JOBSWORTH_CODE_VERSION: ""
@@ -105,9 +102,6 @@ steps:
     environment: prod
     queue: validation_test
   command: integrationtest
-  concurrency: 1
-  concurrency_group: prod/myrepo
-  concurrency_method: eager
   env:
     JOBSWORTH_CAUTIOUS: "0"
     JOBSWORTH_CODE_VERSION: ""


### PR DESCRIPTION
## fix: make deploy steps from different builds unordered

When setting the attribute `concurrency_group` on deploy steps, set `concurrency_method: eager`. By default (`ordered`), a BuildKite build’s `deploy` steps will wait for all the `smoke_test` and build steps of a previous build. This is a problem in rollbacks, which run much faster than normal builds because they have no `smoke_test` or `build` steps, so they are likely to reach their `deploy` steps before the previous build does.

This will make `concurrency:  1` act in a similar manner to controlling concurrency by limiting the number of deploy queues. See [BuildKite Docs: Controlling Concurrency: Controlling command Order](https://buildkite.com/docs/pipelines/controlling-concurrency#concurrency-and-parallelism-controlling-command-order).

## ~~fix: Allow concurrent validation_test steps~~

(this commit was removed)

~~Set the `concurrency` and `concurrency_group` attributes only on `deploy` steps, not `validation_test`, so that a `validation_test` step does not block another BuildKite build’s `deploy` step. Note that one build’s `validation_test` may fail if another build deploys some other code, but that is something we will just have to be aware of when two deploys happen right after each other.~~

~~This will make the behavior more similar to the previous behavior. `validation_test` runs on a different queue than `deploy` so it never used to block `deploy` before we added `concurrency_group`.~~