### PR TITLE
Allow block step

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -203,18 +203,17 @@ func lowerStep(step Step, context *Context, stepContext *StepContext) (Step, err
 	}
 	step["name"] = strings.TrimSpace(fmt.Sprintf(":%s: %s", stepContext.EmojiName, name))
 
-	// Block steps must not contains agents or env, so we return early here
-	_, isBlockStep := step["block"]
-	if isBlockStep {
+	// Block and wait steps must not contains agents or env, so we return early here
+	_, hasBlockStep := step["block"]
+	_, hasWaitStep := step["wait"]
+	if hasBlockStep || hasWaitStep {
 		return step, nil
 	}
 
 	agents, ok := step["agents"].(map[interface{}]interface{})
 	if !ok {
 		agents = make(map[interface{}]interface{})
-		if _, exists := step["wait"]; !exists {
-			step["agents"] = agents
-		}
+		step["agents"] = agents
 	}
 	agents["queue"] = stepContext.QueueName
 	agents["environment"] = stepContext.EnvironmentName
@@ -222,9 +221,7 @@ func lowerStep(step Step, context *Context, stepContext *StepContext) (Step, err
 	env, ok := step["env"].(map[interface{}]interface{})
 	if !ok {
 		env = make(map[interface{}]interface{})
-		if _, exists := step["wait"]; !exists {
-			step["env"] = env
-		}
+		step["env"] = env
 	}
 
 	env["JOBSWORTH_CAUTIOUS"] = stepContext.CautiousStr()

--- a/pipeline.go
+++ b/pipeline.go
@@ -204,9 +204,9 @@ func lowerStep(step Step, context *Context, stepContext *StepContext) (Step, err
 	step["name"] = strings.TrimSpace(fmt.Sprintf(":%s: %s", stepContext.EmojiName, name))
 
 	// Block and wait steps must not contains agents or env, so we return early here
-	_, hasBlockStep := step["block"]
-	_, hasWaitStep := step["wait"]
-	if hasBlockStep || hasWaitStep {
+	_, isBlockStep := step["block"]
+	_, isWaitStep := step["wait"]
+	if isBlockStep || isWaitStep {
 		return step, nil
 	}
 

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -67,6 +67,29 @@ wait: ~
 	}
 }
 
+func TestBlockStep(t *testing.T) {
+	context := &Context{}
+	stepContext := &StepContext{}
+
+	step := Step{}
+	stepBytes := []byte(`
+block: ~
+name: "my block"
+if: 1 == 1
+`)
+	yaml.Unmarshal(stepBytes, &step)
+	step, err := lowerStep(step, context, stepContext)
+	if err != nil {
+		t.Error("lowerStep returned err:", err)
+	}
+	if !reflect.DeepEqual(step["env"], nil) {
+		t.Errorf("env should not be set for a wait step")
+	}
+	if !reflect.DeepEqual(step["agents"], nil) {
+		t.Errorf("agents should not be set for a wait step")
+	}
+}
+
 func TestInterpolate(t *testing.T) {
 	context := &Context{}
 	stepContext := &StepContext{

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -83,10 +83,10 @@ if: 1 == 1
 		t.Error("lowerStep returned err:", err)
 	}
 	if !reflect.DeepEqual(step["env"], nil) {
-		t.Errorf("env should not be set for a wait step")
+		t.Errorf("env should not be set for a block step")
 	}
 	if !reflect.DeepEqual(step["agents"], nil) {
-		t.Errorf("agents should not be set for a wait step")
+		t.Errorf("agents should not be set for a block step")
 	}
 }
 


### PR DESCRIPTION
Block step was not allowed in `.jobsworth.yml`, because Jobsworth automatically adds the `env` and `agents` fields to every step, which are invalid fields for the `block` step.
